### PR TITLE
Allow usage on `no_std` targets and targets using `portable-atomic`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
         if: startsWith(matrix.rust, 'nightly')
         run: cargo check -Z features=dev_dep
       - run: cargo test
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: rustup target add thumbv7m-none-eabi
+      - run: cargo hack build --target thumbv7m-none-eabi --no-default-features --no-dev-deps
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,9 @@ keywords = ["waker", "notify", "wake", "futures", "async"]
 categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
+[dependencies]
+# Uses user-provided critical sections on targets without atomics.
+atomic-polyfill = { version = "1", optional = true }
+
 [dev-dependencies]
 futures = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["/.*"]
 
 [dependencies]
 # Uses portable-atomic polyfill atomics on targets without them 
-portable-atomic = { version = "0.3", optional = true }
+portable-atomic = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
 [dependencies]
-# Uses user-provided critical sections on targets without atomics.
-atomic-polyfill = { version = "1", optional = true }
+# Uses portable-atomic polyfill atomics on targets without them 
+portable-atomic = { version = "0.3", optional = true }
 
 [dev-dependencies]
 futures = "0.3.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 //! `futures::task::AtomicWaker` extracted into its own crate.
-//! 
+//!
 //! # Features
-//! 
+//!
 //! This crate adds a feature, `atomic-polyfill`, which uses a polyfill
 //! from the [`atomic-polyfill`] crate in order to provide functionality
 //! to targets without atomics. See the [`README`] for the [`atomic-polyfill`]
 //! crate for more information on how this is implemented by the end-user.
-//! 
+//!
 //! [`atomic-polyfill`]: https://crates.io/crates/atomic-polyfill
 //! [`README`]: https://github.com/embassy-rs/atomic-polyfill/blob/main/README.md
 
@@ -17,10 +17,10 @@ use core::fmt;
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
 
-#[cfg(not(feature = "atomic-polyfill"))]
-use core::sync::atomic::AtomicUsize;
 #[cfg(feature = "atomic-polyfill")]
 use atomic_polyfill::AtomicUsize;
+#[cfg(not(feature = "atomic-polyfill"))]
+use core::sync::atomic::AtomicUsize;
 
 /// A synchronization primitive for task wakeup.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,26 @@
 //! `futures::task::AtomicWaker` extracted into its own crate.
+//! 
+//! # Features
+//! 
+//! This crate adds a feature, `atomic-polyfill`, which uses a polyfill
+//! from the [`atomic-polyfill`] crate in order to provide functionality
+//! to targets without atomics. See the [`README`] for the [`atomic-polyfill`]
+//! crate for more information on how this is implemented by the end-user.
+//! 
+//! [`atomic-polyfill`]: https://crates.io/crates/atomic-polyfill
+//! [`README`]: https://github.com/embassy-rs/atomic-polyfill/blob/main/README.md
 
-use std::cell::UnsafeCell;
-use std::fmt;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::{AcqRel, Acquire, Release};
-use std::task::Waker;
+#![no_std]
+
+use core::cell::UnsafeCell;
+use core::fmt;
+use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
+use core::task::Waker;
+
+#[cfg(not(feature = "atomic-polyfill"))]
+use core::sync::atomic::AtomicUsize;
+#[cfg(feature = "atomic-polyfill")]
+use atomic_polyfill::AtomicUsize;
 
 /// A synchronization primitive for task wakeup.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@ use core::fmt;
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
 
-#[cfg(feature = "portable-atomic")]
-use portable_atomic::AtomicUsize;
 #[cfg(not(feature = "portable-atomic"))]
 use core::sync::atomic::AtomicUsize;
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicUsize;
 
 /// A synchronization primitive for task wakeup.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ use core::fmt;
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
 
-#[cfg(feature = "atomic-polyfill")]
-use atomic_polyfill::AtomicUsize;
-#[cfg(not(feature = "atomic-polyfill"))]
+#[cfg(feature = "portable-atomic")]
+use portable_atomic::AtomicUsize;
+#[cfg(not(feature = "portable-atomic"))]
 use core::sync::atomic::AtomicUsize;
 
 /// A synchronization primitive for task wakeup.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! # Features
 //!
-//! This crate adds a feature, `atomic-polyfill`, which uses a polyfill
-//! from the [`atomic-polyfill`] crate in order to provide functionality
-//! to targets without atomics. See the [`README`] for the [`atomic-polyfill`]
-//! crate for more information on how this is implemented by the end-user.
+//! This crate adds a feature, `portable-atomic`, which uses a polyfill
+//! from the [`portable-atomic`] crate in order to provide functionality
+//! to targets without atomics. See the [`README`] for the [`portable-atomic`]
+//! crate for more information on how to use it on single-threaded targets.
 //!
-//! [`atomic-polyfill`]: https://crates.io/crates/atomic-polyfill
-//! [`README`]: https://github.com/embassy-rs/atomic-polyfill/blob/main/README.md
+//! [`portable-atomic`]: https://crates.io/crates/portable-atomic
+//! [`README`]: https://github.com/taiki-e/portable-atomic/blob/main/README.md#optional-cfg
 
 #![no_std]
 


### PR DESCRIPTION
This pull requests replaces this crate's dependency on `libstd` with `libcore`, allowing it to be used on `no_std` targets. In addition, it adds a feature called `atomic-polyfill`, which uses the crate of the same name to provide `AtomicUsize` on `no_std` targets.