### PR TITLE
Use `Waker::will_wake()` to avoid a cloning op

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,12 @@ impl AtomicWaker {
             WAITING => {
                 unsafe {
                     // Locked acquired, update the waker cell
-                    *self.waker.get() = Some(waker.clone());
+
+                    // Avoid cloning the waker if the old waker will awaken the same task.
+                    match &*self.waker.get() {
+                        Some(old_waker) if old_waker.will_wake(waker) => (),
+                        _ => *self.waker.get() = Some(waker.clone()),
+                    }
 
                     // Release the lock. If the state transitioned to include
                     // the `WAKING` bit, this means that at least one wake has


### PR DESCRIPTION
This uses [`Waker::will_wake()`](https://doc.rust-lang.org/stable/std/task/struct.Waker.html#method.will_wake) to check if the old waker will awaken the same task as the new one, which could save a clone operation.

Fixes #11.