### PR TITLE
Improve wake performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,11 +403,11 @@ impl AtomicWaker {
         // memory the `AtomicWaker` is associated with.
         match self.state.fetch_or(WAKING, AcqRel) {
             WAITING => {
-                // The waking lock has been acquired.
+                // SAFETY: The waking lock has been acquired.
                 let waker = unsafe { (*self.waker.get()).take() };
 
-                // Release the lock
-                self.state.fetch_and(!WAKING, Release);
+                // Release the lock.
+                self.state.store(WAITING, Release);
 
                 waker
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,7 +407,7 @@ impl AtomicWaker {
                 let waker = unsafe { (*self.waker.get()).take() };
 
                 // Release the lock.
-                self.state.store(WAITING, Release);
+                self.state.swap(WAITING, Release);
 
                 waker
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,7 +407,8 @@ impl AtomicWaker {
                 let waker = unsafe { (*self.waker.get()).take() };
 
                 // Release the lock.
-                self.state.swap(WAITING, Release);
+                let old_state = self.state.swap(WAITING, Release);
+                debug_assert!(old_state == WAKING);
 
                 waker
             }


### PR DESCRIPTION
## Motivation

The `AtomicWaker` does a read-modify-write operation to release its lock on the state, but this is not necessary.
The only other place `state` can be modified concurrently is through another `fetch_or(WAKING)` in `fn take` (a no-op since the state is already `WAKING`), or through a `compare_exchange(WAITING, REGISTERING)` in `fn register`, however this will always fail as we are currently in `WAKING`. Thus we know with 100% certainty the state is `WAKING` and will remain so, so the `fetch_and(!WAKING)` is equivalent to just storing `WAITING`.

One other reason one might use a read-modify-write operation instead of a simple store is if one is also `Acquire`ing. But here we only use `Release`, so the read portion of the atomic operation is entirely unnecessary.

## Solution

~~I changed the release  of the lock to a simple `Release` `store`.~~

As Darksonn points out in the Tokio PR out we still need to store with a read-modify-write operation to ensure the release sequence from wake-during-wakes stays intact. So I changed the release to a `swap` which is still more efficient than a `fetch_and`.


---

This PR is essentially a copy of my PR to Tokio here: https://github.com/tokio-rs/tokio/pull/7450.