### PR TITLE
Implement UnwindSafe and RefUnwindSafe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: taiki-e/checkout-action@v1
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-      - run: cargo hack build --rust-version
+      - run: cargo hack build --rust-version --no-dev-deps
 
   miri:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
   "Contributors to futures-rs",
 ]
 edition = "2018"
-rust-version = "1.36"
+rust-version = "1.56"
 description = "A synchronization primitive for task wakeup"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/atomic-waker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",
 ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 description = "A synchronization primitive for task wakeup"
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 
 use core::cell::UnsafeCell;
 use core::fmt;
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
 
@@ -458,3 +459,9 @@ impl fmt::Debug for AtomicWaker {
 
 unsafe impl Send for AtomicWaker {}
 unsafe impl Sync for AtomicWaker {}
+
+// SAFETY: all accesses to the UnsafeCell are guarded by atomic operations.
+// In the unlikely event where waker.clone would panic, we restore the previous atomic state to heal
+// ourselves and not get indefinitely stuck in REGISTERING when unwinding.
+impl UnwindSafe for AtomicWaker {}
+impl RefUnwindSafe for AtomicWaker {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,22 @@ impl AtomicWaker {
                     // Avoid cloning the waker if the old waker will awaken the same task.
                     match &*self.waker.get() {
                         Some(old_waker) if old_waker.will_wake(waker) => (),
-                        _ => *self.waker.get() = Some(waker.clone()),
+                        _ => {
+                            // If `waker.clone()` panics, we would end up permanently stuck in REGISTERING
+                            // state. Let's add a safeguard that resets it to WAITING in that specific case.
+                            struct ResetOnDrop<'a>(&'a AtomicUsize);
+                            impl Drop for ResetOnDrop<'_> {
+                                fn drop(&mut self) {
+                                    self.0.swap(WAITING, AcqRel);
+                                }
+                            }
+                            let guard = ResetOnDrop(&self.state);
+
+                            *self.waker.get() = Some(waker.clone());
+
+                            // Now that clone is done, let's defuse the safeguard.
+                            core::mem::forget(guard);
+                        }
                     }
 
                     // Release the lock. If the state transitioned to include


### PR DESCRIPTION
I recently switched from some custom handling to using AtomicWaker, but lost UnwindSafe in the process, due to the use of UnsafeCell.
When digging around, it felt safe to implement them as access is guarded by atomic operations. The only thing that pop to mind was the MSRV, since UnwindSafe got added in 1.56 (alongside edition 2021).

Running claude to check if I wasn't missing anything, it taised the fact that we could end up stuck in REGISTERING state if waker.clone would ever panic. It feels sensible and doesn't add a lot of noise, so I figured it didn't hurt adding a safeguard, but I can drop that part if you think it shouldn't be there.

Would you be ok with raising MSRV to 1.56, since lots of smol crates already depend on newer versions?
If we raise it, it seems to make sense to switch to edition 2021 while at it.